### PR TITLE
fix timeout parameter not used

### DIFF
--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -157,7 +157,7 @@ Client TcpServer::acceptClient(uint timeout) {
 
     if (timeout > 0) {
         struct timeval tv;
-        tv.tv_sec = 2;
+        tv.tv_sec = timeout;
         tv.tv_usec = 0;
         FD_ZERO(&m_fds);
         FD_SET(m_sockfd, &m_fds);


### PR DESCRIPTION
This PR fix the issue #6 by replacing the literal 2 by the proper `timeout` parameter.