### PR TITLE
clear msg

### DIFF
--- a/src/tcp_client.cpp
+++ b/src/tcp_client.cpp
@@ -127,6 +127,7 @@ void TcpClient::receiveTask() {
         }
 
         char msg[MAX_PACKET_SIZE];
+        memset(msg, '\0', sizeof(msg)); 
         const size_t numOfBytesReceived = recv(_sockfd.get(), msg, MAX_PACKET_SIZE, 0);
 
         if(numOfBytesReceived < 1) {


### PR DESCRIPTION
Client Recv Error.

First time：
server send: `abcdef`
client recv: `abcdef`
Second time：
server send: `www`
client recv: `wwwdef`   but client recv should be `www` only

![image](https://user-images.githubusercontent.com/68001817/159614255-03139ede-1428-4372-9ee3-d442b26a26ed.png)
![image](https://user-images.githubusercontent.com/68001817/159614314-de1491bf-b4f5-4c17-839f-aff3278881fb.png)



<font color=red>**After modification**</font>：

![image](https://user-images.githubusercontent.com/68001817/159614505-d003e5fe-2cff-4037-8461-5e586a83d12d.png)
![image](https://user-images.githubusercontent.com/68001817/159614534-18557588-d2e7-41f8-8af0-53933b2d4a85.png)


