### PR TITLE
Fix bug when the previous data sent was larger

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -71,7 +71,7 @@ void Client::receiveTask() {
             publishEvent(ClientEvent::DISCONNECTED, disconnectionMessage);
             return;
         } else {
-            publishEvent(ClientEvent::INCOMING_MSG, receivedMessage);
+            publishEvent(ClientEvent::INCOMING_MSG, std::string(receivedMessage, numOfBytesReceived));
         }
     }
 }


### PR DESCRIPTION
There is a bug when you send some data, and then in a second communication with smaller data you can see at the end of the the previous last part of the larger data. Then the size obtained is the same in both cases.